### PR TITLE
is_login修正

### DIFF
--- a/backend/src/utils/auth/auth.py
+++ b/backend/src/utils/auth/auth.py
@@ -24,6 +24,8 @@ def is_login(session_id: Optional[str] = Cookie(None)):
 # cookieからsession_id取り出す
     res = {"session_id": session_id}
     session_id = res["session_id"]
+    if session_id is None:
+       return False
     print(session_id)
 # session_idの存在ck
     if r.exists(session_id) == 0:


### PR DESCRIPTION
```
    if session_id is None:
       return False
```
上記入れたのでsession_idがそもそもなかった場合は
”"ログイン情報がありません"のエラーが返されると思います