### PR TITLE
借り手の取引評価ボタン表示切り替え

### DIFF
--- a/frontend/src/pages/mypage/orders/borrow/[id].tsx
+++ b/frontend/src/pages/mypage/orders/borrow/[id].tsx
@@ -175,27 +175,32 @@ const MypageOrderDetailBorrower = ({ result }: OrderProps) => {
                         </h4>
                       </div>
                       <div className="my-8">
-                      {/*予約ステータスにより表示切替 2列　status渡す*/}
-                      {order[0].status !== "予約確定" &&
-                      order[0].status !== "貸出中" ? (
-                        <></>
-                      ) : (
-                        <QrGenerator
-                          qrText={`予約番号：${order[0]._id}, 品名:${order[0].items_copy?.name}, 貸出日:${order[0].period?.start}, 返却日:${order[0].period.start}`}
-                        />
-                      )}
-                      {order[0]?.status === "返却完了" && (
-                        <>
-                          <Link
-                            href={{
-                              pathname: "/mypage/orders/borrow/evaluation/[id]",
-                              query: { id: `${orderId}&${order[0]?.lender._id}`},
-                            }}
-                          >
-                            <Button>取引を評価</Button>
-                          </Link>
-                        </>
-                      )}
+                        {/*予約ステータスにより表示切替 2列　status渡す*/}
+                        {order[0].status !== "予約確定" &&
+                        order[0].status !== "貸出中" ? (
+                          <></>
+                        ) : (
+                          <QrGenerator
+                            qrText={`予約番号：${order[0]._id}, 品名:${order[0].items_copy?.name}, 貸出日:${order[0].period?.start}, 返却日:${order[0].period.start}`}
+                          />
+                        )}
+                        
+                        {order[0]?.status === "返却完了" &&
+                          !order[0]?.lender.evaluation && (
+                            <>
+                              <Link
+                                href={{
+                                  pathname:
+                                    "/mypage/orders/borrow/evaluation/[id]",
+                                  query: {
+                                    id: `${orderId}&${order[0]?.lender._id}`,
+                                  },
+                                }}
+                              >
+                                <Button>取引を評価</Button>
+                              </Link>
+                            </>
+                          )}
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
借り手の取引を評価するボタンの表示は、reservationの
statusが”返却完了”かつlenderのevaluationが空欄（"")の時に表示されるように変更しました

・貸し手と借り手で評価タイミングが異なるので、予約ステータスの種類に"評価完了"を設定するのはやめでお願いします